### PR TITLE
Send applications to admin chat

### DIFF
--- a/handlers/admin_actions.py
+++ b/handlers/admin_actions.py
@@ -6,6 +6,9 @@ router = Router()
 
 @router.callback_query()
 async def process_admin_action(query: types.CallbackQuery) -> None:
+    if query.message.chat.id != settings.ADMIN_CHAT_ID:
+        await query.answer()
+        return
     if query.data == "approve":
         await query.message.answer("Заявка одобрена")
     elif query.data == "decline":


### PR DESCRIPTION
## Summary
- forward seeker & owner forms to the admin chat with all fields and photos
- add inline buttons for approvers
- guard callbacks in admin chat only

## Testing
- `python -m py_compile handlers/owner_form.py handlers/seeker_form.py handlers/admin_actions.py`

------
https://chatgpt.com/codex/tasks/task_e_684844163df083249fb47a73af58acc7