### PR TITLE
Fix stray main in main_menu

### DIFF
--- a/handlers/main_menu.py
+++ b/handlers/main_menu.py
@@ -11,7 +11,6 @@ async def cmd_start(message: types.Message) -> None:
     kb.button(text="🐣 Хочу приютить")
     kb.button(text="🔄 Отдать птицу")
     
-main
     kb.adjust(1, 1)
     await message.answer(
         "Выберите действие:", reply_markup=kb.as_markup(resize_keyboard=True)


### PR DESCRIPTION
## Summary
- remove stray `main` line from `handlers/main_menu.py`

## Testing
- `python -m py_compile handlers/main_menu.py`


------
https://chatgpt.com/codex/tasks/task_e_68484762e7fc8324a7d8ade98783bb7d